### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/test_multiuser.py
+++ b/test_multiuser.py
@@ -34,8 +34,8 @@ async def test_multi_user():
             if resp.status == 200:
                 user1 = await resp.json()
                 print(f"   User created: {user1['username']}")
-                print(f"   API Key: {user1['api_key'][:20]}...")
-                print(f"   Token: {user1['token'][:20]}...\n")
+                print("   API Key: <redacted>")
+                print("   Token: <redacted>\n")
                 user1_token = user1['token']
                 user1_api_key = user1['api_key']
             else:
@@ -58,8 +58,8 @@ async def test_multi_user():
             if resp.status == 200:
                 user2 = await resp.json()
                 print(f"   User created: {user2['username']}")
-                print(f"   API Key: {user2['api_key'][:20]}...")
-                print(f"   Token: {user2['token'][:20]}...\n")
+                print("   API Key: <redacted>")
+                print("   Token: <redacted>\n")
             else:
                 error = await resp.text()
                 print(f"   Error: {error}\n")


### PR DESCRIPTION
Potential fix for [https://github.com/DaddyFilth/ai-service/security/code-scanning/4](https://github.com/DaddyFilth/ai-service/security/code-scanning/4)

In general, to fix clear-text logging of sensitive information, remove or redact sensitive fields (passwords, API keys, tokens, secrets) before logging. If you still need to confirm their presence for debugging, log only high-level metadata such as whether a key/token was issued, its length, or a non-sensitive identifier.

For this specific file, the safest change without altering the functional behavior of the test is to stop printing the actual API key and token content for both users. The test only uses `user1['api_key']` and `user1['token']` by assigning them to `user1_api_key` and `user1_token`; there is no need to show these values. So:

- Replace the lines that print `API Key: {user1['api_key'][:20]}...` and `Token: {user1['token'][:20]}...` with non-sensitive messages that confirm an API key and token were returned, such as `API Key: <redacted>` and `Token: <redacted>`.
- Similarly, for user 2, replace the lines that print `API Key: {user2['api_key'][:20]}...` and `Token: {user2['token'][:20]}...` (the snippet shows only API Key, but we will assume a parallel Token line exists nearby) with redacted or generic messages.
- No new imports or methods are required; we just change the string contents being printed.

All edits are within `test_multiuser.py` in the shown regions around lines 37–38 and 61–62.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
